### PR TITLE
fix: swap around icons for vencord plugins

### DIFF
--- a/src/global/icons.scss
+++ b/src/global/icons.scss
@@ -167,12 +167,12 @@
 	"aria-label",
 	(
 		// Everything below until last comment is in the message form
-		"Disable Game Activity": "xbox-controller-none",
-		"Disable Silent Message": "bell-outline-none",
-		"Disable Silent Typing": "keyboard3-none",
-		"Enable Game Activity": "xbox-controller",
-		"Enable Silent Message": "bell-outline",
-		"Enable Silent Typing": "keyboard3",
+		"Disable Game Activity": "xbox-controller",
+		"Disable Silent Message": "bell-outline",
+		"Disable Silent Typing": "keyboard3",
+		"Enable Game Activity": "xbox-controller-none",
+		"Enable Silent Message": "bell-outline-none",
+		"Enable Silent Typing": "keyboard3-none",
 		"Encrypt Message": "padlock2",
 		"Open Translate Modal": "translate",
 		// Message actions


### PR DESCRIPTION
Hey, really enjoying the theme so far! I just noticed a small issue, which was a quick fix.

The logic was switched here. When the label "Enable Game Activity" is shown, it means that the game activity is disabled, so we need the `none` icons, in order to align with the default behavior.

This is what it looks like right now with the theme 
![image](https://github.com/user-attachments/assets/a21e2cd4-5866-42fc-b63e-77c17d1af050)
and without it
![image](https://github.com/user-attachments/assets/e5ab79b1-4533-41b5-a4b1-e8eaf7f550ec)