### PR TITLE
Vesktop settings fix

### DIFF
--- a/src/vencord/components.scss
+++ b/src/vencord/components.scss
@@ -10,6 +10,7 @@
 
 	&.vc-btn-primary {
 		@include controls.button-accent;
+		margin-top: 10px;
 	}
 }
 

--- a/src/vencord/settings.scss
+++ b/src/vencord/settings.scss
@@ -73,3 +73,11 @@
 
 	grid-template-columns: 1fr;
 }
+
+.vcd-settings-category-content {
+    gap: 0 !important;
+}
+
+.vcd-settings-category {
+    margin-top: 16px;
+}


### PR DESCRIPTION
Fixed the spacing on Vesktop settings page for toggles and buttons. This also fixes (most of) issue #18 
<img width="1410" height="1033" alt="image" src="https://github.com/user-attachments/assets/0a9d5da0-cfdb-43d5-84d2-5a44bd6af702" />
