### PR TITLE
Fix extra padding in online friends list border

### DIFF
--- a/src/content/views/friends.scss
+++ b/src/content/views/friends.scss
@@ -30,6 +30,7 @@
 	@include controls.cards-container;
 
 	overflow: auto;
+	padding-bottom: 0;
 
 	& > div > div {
 		@include controls.card-in-container(


### PR DESCRIPTION
Added missing value to friends.scss to fix additional 8px padding at bottom of friends list reported in issue #54 

<img width="445" height="340" alt="Screenshot From 2025-11-10 11-48-20" src="https://github.com/user-attachments/assets/6ce2b0aa-cfbf-4b03-af08-6d6898f89215" />
