### PR TITLE
Update outdated user sidepanel refs/ fix Issue #58

### DIFF
--- a/src/dialogs/user-profile.scss
+++ b/src/dialogs/user-profile.scss
@@ -153,11 +153,10 @@
 	.inner_c0bea0 {
 		gap: 0;
 	}
-
+}
 .outer_c0bea0.user-profile-sidebar {
 	border-radius: 0;
 	}
-}
 
 .profile__9c3be {
 	outline: 0;


### PR DESCRIPTION
fixed reference to outdated profile sidebar name and set radius to 0, fixing issue #58 

<img width="496" height="83" alt="Screenshot From 2025-11-11 12-52-07" src="https://github.com/user-attachments/assets/1b08eb6f-c3d6-4c3a-9684-d7a4ea09a87c" />
