### PR TITLE
Fix issue #58 without touching modal

### DIFF
--- a/src/dialogs/user-profile.scss
+++ b/src/dialogs/user-profile.scss
@@ -157,7 +157,7 @@
 
 .outer_c0bea0.user-profile-sidebar {
 	border-radius: 0;
-	}
+}
 
 .profile__9c3be {
 	outline: 0;


### PR DESCRIPTION
This is a revised fix for #58 that doesn't touch the existing css for the modal

<img width="496" height="83" alt="image" src="https://github.com/user-attachments/assets/7e08d4fe-05d3-4611-ae60-8dcf0a7d0f3f" />
