### PR TITLE
Fix vencord quick settings

### DIFF
--- a/src/vencord/settings.scss
+++ b/src/vencord/settings.scss
@@ -112,9 +112,9 @@
 	&,
 	&:hover,
 	&:active {
-			&::before,
-			&::after {
-					display: none;
+		&::before,
+		&::after {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
-hide broken popup for pseudo buttons in vencord settings 
-fixed quick settings icon alignment #65 

<img width="803" height="581" alt="Screenshot From 2025-11-24 00-25-37" src="https://github.com/user-attachments/assets/760a8bcc-e278-470f-9237-b095a7cd6476" />
