### PR TITLE
refactor: overhaul chat header layout with improved search bar animations and icon updates

### DIFF
--- a/src/content/header/chat.scss
+++ b/src/content/header/chat.scss
@@ -4,7 +4,7 @@
 
 :root {
 	--chat-header-right-padding: calc(
-		var(--titlebar-right-spacing) + var(--icon-button-size) + var(--spacing)
+		var(--titlebar-right-spacing) + var(--spacing)
 	);
 }
 
@@ -26,8 +26,11 @@
 		box-shadow: var(--elevation-low);
 	}
 
-	&:has(.search_c322aa:focus-within, .icon_c322aa.pointer_fea832) {
-		height: calc(var(--headerbar-height) * 2);
+	&:has(.search_c322aa:focus-within) {
+		.children__9293f {
+			opacity: 0;
+			pointer-events: none;
+		}
 	}
 
 	// home
@@ -38,6 +41,20 @@
 	.avatar_f75fb0 {
 		margin-left: 0;
 		margin-right: var(--spacing);
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+
+		svg,
+		foreignObject,
+		img {
+			width: 100% !important;
+			height: 100% !important;
+			mask: none !important;
+			border-radius: 50%;
+			x: 0 !important;
+			y: 0 !important;
+		}
 	}
 
 	// Experiments vencord plugin
@@ -51,9 +68,11 @@
 
 	min-height: var(--headerbar-height);
 	display: flex;
-	justify-content: center;
+	justify-content: flex-start;
 
 	app-region: drag;
+
+	transition: opacity 200ms ease;
 
 	&:not(:has(.avatar_f75fb0)) {
 		flex-direction: column;
@@ -152,30 +171,59 @@
 
 .search__49676 {
 	margin: 0 var(--spacing);
+	width: var(--icon-button-size);
+	max-width: var(--icon-button-size);
+	min-width: unset;
 
 	position: absolute;
 	left: 0;
+	top: calc((var(--headerbar-height) - var(--icon-button-size)) / 2) !important;
+	z-index: 10;
+	overflow: hidden;
+
+	-webkit-app-region: no-drag !important;
+	app-region: no-drag !important;
+
+	transition: width 200ms ease, max-width 200ms ease;
+
+	&:focus-within {
+		width: 240px;
+		max-width: 240px;
+	}
+
+	&:not(:focus-within) {
+		.DraftEditor-root {
+			opacity: 0 !important;
+			pointer-events: none !important;
+		}
+	}
 
 	.DraftEditor-editorContainer {
 		height: unset;
 	}
 
 	.DraftEditor-root {
-		@include controls.text-field;
-
 		font-weight: normal;
-
-		position: absolute;
-		top: var(--headerbar-height);
-		left: 0;
-		width: 250px;
+		width: 100%;
+		display: flex !important;
+		align-items: center !important;
+		height: 100% !important;
+		opacity: 1 !important;
+		pointer-events: auto !important;
 	}
 
-	.public-DraftEditor-content,
+	.public-DraftEditor-content {
+		padding: 0 !important;
+		margin: 0 !important;
+	}
+
 	.public-DraftEditorPlaceholder-root {
-		padding: 0;
-		padding-left: 2px;
-		margin-block: 1px -1px;
+		position: absolute !important;
+		top: 50% !important;
+		transform: translateY(-50%) !important;
+		left: 2px !important;
+		padding: 0 !important;
+		margin: 0 !important;
 	}
 
 	.searchAnswer_bd8186,
@@ -198,11 +246,32 @@
 	border: none;
 	border-radius: var(--button_radius);
 
-	width: var(--icon-button-size);
+	width: 100%;
 	height: var(--icon-button-size);
 	flex-direction: row-reverse;
 
 	transition: var(--backdrop_transition);
+
+	&:focus-within {
+		@include controls.text-field;
+		background-color: var(--view_bg_color) !important;
+		height: var(--icon-button-size) !important;
+		padding-inline: var(--spacing) !important;
+		padding-block: 0 !important;
+		box-sizing: border-box !important;
+		display: flex !important;
+		align-items: center !important;
+
+		.icon_c322aa {
+			background: none !important;
+			pointer-events: none !important;
+			box-shadow: none !important;
+
+			&::after {
+				display: none !important;
+			}
+		}
+	}
 }
 
 .title__9293f {

--- a/src/global/icons.scss
+++ b/src/global/icons.scss
@@ -75,8 +75,10 @@
 @include -gen-icons(
 	"aria-label",
 	(
+		"Add Friends": "contact-new",
 		"Add Friends to DM": "contact-new",
 		"Add Friends to Group DM": "contact-new",
+		"Add to DM": "contact-new",
 		// TODO(experiment): remove later ? nitro only
 		"Bookmarks": "user-bookmarks",
 		"DevTools": "build-alt",

--- a/src/global/variables/window-decorations.scss
+++ b/src/global/variables/window-decorations.scss
@@ -9,7 +9,7 @@
 	--titlebar-maximize-button: none;
 	--titlebar-minimize-button: none;
 	/* also set this to how much buttons are visible */
-	--titlebar-buttons-count: 1;
+	--titlebar-buttons-count: 3;
 
 	&.platform-win {
 		--app-border-size: 1px;

--- a/src/popovers/search.scss
+++ b/src/popovers/search.scss
@@ -16,7 +16,7 @@
 .container__16eb0:not(:empty) {
 	@include popover.container;
 
-	margin-block-start: calc(var(--headerbar-height) + var(--spacing));
+	margin-block-start: var(--spacing) !important;
 
 	[data-text-variant] {
 		font-size: var(--document-font-size);


### PR DESCRIPTION
I modified areas that had some stylistic issues and associated icons to the missing buttons. I moved the channel search bar to be inline with the channel bar for a cleaner look.

<img width="1717" height="172" alt="image" src="https://github.com/user-attachments/assets/2e179b9c-89e9-4acc-8174-9230a9e44b78" />
<img width="1717" height="172" alt="image" src="https://github.com/user-attachments/assets/14e5246d-67f2-4171-a844-c88613b45df7" />
<img width="1712" height="157" alt="Screenshot From 2026-06-14 02-42-21" src="https://github.com/user-attachments/assets/57faeef3-6742-4669-bedc-86fad7191368" />
